### PR TITLE
Remove implicit namespacing

### DIFF
--- a/lib/curve.js
+++ b/lib/curve.js
@@ -1,25 +1,25 @@
 var BigInteger = require('bigi')
 
-var ECPointFp = require('./point')
+var Point = require('./point')
 
-module.exports = ECCurveFp
+module.exports = Curve
 
-function ECCurveFp(p, a, b) {
+function Curve(p, a, b) {
   this._p = p
   this._a = a
   this._b = b
-  this.infinity = new ECPointFp(this, null, null)
+  this.infinity = new Point(this, null, null)
 }
 
-Object.defineProperty(ECCurveFp.prototype, 'p', {get: function() { return this._p }})
-Object.defineProperty(ECCurveFp.prototype, 'a', {get: function() { return this._a }})
-Object.defineProperty(ECCurveFp.prototype, 'b', {get: function() { return this._b }})
+Object.defineProperty(Curve.prototype, 'p', {get: function() { return this._p }})
+Object.defineProperty(Curve.prototype, 'a', {get: function() { return this._a }})
+Object.defineProperty(Curve.prototype, 'b', {get: function() { return this._b }})
 
-ECCurveFp.prototype.equals = function(other) {
+Curve.prototype.equals = function(other) {
   if (other == this) return true
   return (this.p.equals(other.p) && this.a.equals(other.a) && this.b.equals(other.b))
 }
 
-ECCurveFp.prototype.getInfinity = function() {
+Curve.prototype.getInfinity = function() {
   return this.infinity
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,14 +1,14 @@
-var ECPointFp = require('./point')
-var ECCurveFp = require('./curve')
+var Point = require('./point')
+var Curve = require('./curve')
 
 var getECParams = require('./names')
 
 //for legacy compatibility, remove in the future
-ECCurveFp.ECPointFp = ECPointFp
+Curve.Point = Point
 
 module.exports = {
-  ECCurveFp: ECCurveFp,
-  ECPointFp: ECPointFp,
+  Curve: Curve,
+  Point: Point,
   getECParams: getECParams
 }
 

--- a/lib/point.js
+++ b/lib/point.js
@@ -3,7 +3,7 @@ var BigInteger = require('bigi')
 
 var THREE = BigInteger.valueOf(3)
 
-function ECPointFp(curve, x, y, z) {
+function Point(curve, x, y, z) {
   z = z || BigInteger.ONE
 
   this.curve = curve
@@ -18,7 +18,7 @@ function ECPointFp(curve, x, y, z) {
   this.compressed = true
 }
 
-ECPointFp.prototype.getX = function() {
+Point.prototype.getX = function() {
   if (this.zinv === null) {
     this.zinv = this.z.modInverse(this.curve.p)
   }
@@ -26,7 +26,7 @@ ECPointFp.prototype.getX = function() {
   return this.x.multiply(this.zinv).mod(this.curve.p)
 }
 
-ECPointFp.prototype.getY = function() {
+Point.prototype.getY = function() {
   if (this.zinv === null) {
     this.zinv = this.z.modInverse(this.curve.p)
   }
@@ -34,7 +34,7 @@ ECPointFp.prototype.getY = function() {
   return this.y.multiply(this.zinv).mod(this.curve.p)
 }
 
-ECPointFp.prototype.equals = function(other) {
+Point.prototype.equals = function(other) {
   if (other == this) return true
   if (this.isInfinity()) return other.isInfinity()
   if (other.isInfinity()) return this.isInfinity()
@@ -50,18 +50,18 @@ ECPointFp.prototype.equals = function(other) {
   return v.signum() === 0
 }
 
-ECPointFp.prototype.isInfinity = function() {
+Point.prototype.isInfinity = function() {
   if ((this.x === null) && (this.y === null)) return true
   return this.z.signum() === 0 && this.y.signum() !== 0
 }
 
-ECPointFp.prototype.negate = function() {
+Point.prototype.negate = function() {
   var y = this.y.negate().mod(this.curve.p)
 
-  return new ECPointFp(this.curve, this.x, y, this.z)
+  return new Point(this.curve, this.x, y, this.z)
 }
 
-ECPointFp.prototype.add = function(b) {
+Point.prototype.add = function(b) {
   if (this.isInfinity()) return b
   if (b.isInfinity()) return this
 
@@ -95,10 +95,10 @@ ECPointFp.prototype.add = function(b) {
   // z3 = v^3 * z1 * z2
   var z3 = v3.multiply(this.z).multiply(b.z).mod(this.curve.p)
 
-  return new ECPointFp(this.curve, x3, y3, z3)
+  return new Point(this.curve, x3, y3, z3)
 }
 
-ECPointFp.prototype.twice = function() {
+Point.prototype.twice = function() {
   if (this.isInfinity()) return this
   if (this.y.signum() === 0) return this.curve.getInfinity()
 
@@ -124,12 +124,12 @@ ECPointFp.prototype.twice = function() {
   // z3 = 8 * (y1 * z1)^3
   var z3 = y1z1.pow(3).shiftLeft(3).mod(this.curve.p)
 
-  return new ECPointFp(this.curve, x3, y3, z3)
+  return new Point(this.curve, x3, y3, z3)
 }
 
 // Simple NAF (Non-Adjacent Form) multiplication algorithm
 // TODO: modularize the multiplication algorithm
-ECPointFp.prototype.multiply = function(k) {
+Point.prototype.multiply = function(k) {
   if (this.isInfinity()) return this
   if (k.signum() === 0) return this.curve.getInfinity()
 
@@ -154,7 +154,7 @@ ECPointFp.prototype.multiply = function(k) {
 }
 
 // Compute this*j + x*k (simultaneous multiplication)
-ECPointFp.prototype.multiplyTwo = function(j, x, k) {
+Point.prototype.multiplyTwo = function(j, x, k) {
   var i
 
   if (j.bitLength() > k.bitLength())
@@ -185,7 +185,7 @@ ECPointFp.prototype.multiplyTwo = function(j, x, k) {
   return R
 }
 
-ECPointFp.prototype.getEncoded = function(compressed) {
+Point.prototype.getEncoded = function(compressed) {
   if (compressed == undefined) compressed = this.compressed
   if (this.isInfinity()) return new Buffer('00', 'hex') // Infinity point encoded is simply '00'
 
@@ -214,7 +214,7 @@ ECPointFp.prototype.getEncoded = function(compressed) {
   return buffer
 }
 
-ECPointFp.decodeFrom = function(curve, buffer) {
+Point.decodeFrom = function(curve, buffer) {
   var type = buffer.readUInt8(0);
   var compressed = (type !== 4)
   var x = BigInteger.fromBuffer(buffer.slice(1, 33))
@@ -250,12 +250,12 @@ ECPointFp.decodeFrom = function(curve, buffer) {
     y = BigInteger.fromBuffer(buffer.slice(1 + byteLength))
   }
 
-  var pt = new ECPointFp(curve, x, y)
+  var pt = new Point(curve, x, y)
   pt.compressed = compressed
   return pt
 }
 
-ECPointFp.prototype.isOnCurve = function() {
+Point.prototype.isOnCurve = function() {
   if (this.isInfinity()) return true
 
   var x = this.getX()
@@ -274,7 +274,7 @@ ECPointFp.prototype.isOnCurve = function() {
   return lhs.equals(rhs)
 }
 
-ECPointFp.prototype.toString = function () {
+Point.prototype.toString = function () {
   if (this.isInfinity()) return '(INFINITY)'
 
   return '(' + this.getX().toString() + ',' + this.getY().toString() + ')'
@@ -285,7 +285,7 @@ ECPointFp.prototype.toString = function () {
  *
  * See SEC 1, section 3.2.2.1: Elliptic Curve Public Key Validation Primitive
  */
-ECPointFp.prototype.validate = function() {
+Point.prototype.validate = function() {
   // Check Q != O
   assert(!this.isInfinity(), 'Point is at infinity')
   assert(this.isOnCurve(), 'Point is not on the curve')
@@ -297,4 +297,4 @@ ECPointFp.prototype.validate = function() {
   return true
 }
 
-module.exports = ECPointFp
+module.exports = Point

--- a/test/curve.test.js
+++ b/test/curve.test.js
@@ -2,8 +2,8 @@ var assert = require('assert')
 
 var BigInteger = require('bigi')
 var ecurve = require('../')
-var ECCurveFp = ecurve.ECCurveFp
-var ECPointFp = ecurve.ECPointFp
+var Curve = ecurve.Curve
+var Point = ecurve.Point
 
 var fixtures = require('./fixtures/curve')
 
@@ -13,7 +13,7 @@ describe('Ecurve', function() {
     var a = BigInteger.valueOf(22)
     var b = BigInteger.valueOf(33)
 
-    var curve = new ECCurveFp(p, a, b)
+    var curve = new Curve(p, a, b)
     assert.equal(curve.p.toString(), '11')
     assert.equal(curve.a.toString(), '22')
     assert.equal(curve.b.toString(), '33')
@@ -55,7 +55,7 @@ describe('Ecurve', function() {
     //    0 1  2  3  4  5  6  7  8  9 10
     ///////////////////////////////////////////////
 
-    var curve = new ECCurveFp(BigInteger.valueOf(11), BigInteger.ONE, BigInteger.ZERO)
+    var curve = new Curve(BigInteger.valueOf(11), BigInteger.ONE, BigInteger.ZERO)
     var points = [
       { x: 0, y: 0 },
       { x: 5, y: 8 }, { x: 5, y: 3 },
@@ -64,7 +64,7 @@ describe('Ecurve', function() {
       { x: 9, y: 10 }, { x: 9, y: 1 },
       { x: 10, y: 8 }, { x: 10, y: 3 }
     ].map(function(p) {
-      return new ECCurveFp.ECPointFp(curve, BigInteger.valueOf(p.x), BigInteger.valueOf(p.y))
+      return new Curve.Point(curve, BigInteger.valueOf(p.x), BigInteger.valueOf(p.y))
     })
     var params = {
       curve: curve,
@@ -86,7 +86,7 @@ describe('Ecurve', function() {
     var a = points[2]
     var b = points[7]
     var z = points[0]
-    var y = new ECPointFp(curve, BigInteger.ONE, BigInteger.ONE)
+    var y = new Point(curve, BigInteger.ONE, BigInteger.ONE)
 
     it('should validate field elements properly', function() {
       assert.ok(a.validate())
@@ -157,12 +157,12 @@ describe('Ecurve', function() {
       var p1 = BigInteger.fromHex("FFFFFFFDFFFFFFFFFFFFFFFFFFFFFFFF")
       var a1 = BigInteger.fromHex("FFFFFFFDFFFFFFFFFFFFFFFFFFFFFFFC")
       var b1 = BigInteger.fromHex("E87579C11079F43DD824993C2CEE5ED3")
-      var curve1 = new ECCurveFp(p1, a1, b1)
+      var curve1 = new Curve(p1, a1, b1)
 
       var p2 = p1.clone()
       var a2 = a1.clone()
       var b2 = b1.clone()
-      var curve2 = new ECCurveFp(p2, a2, b2)
+      var curve2 = new Curve(p2, a2, b2)
 
       assert(curve1.equals(curve2))
       assert(curve2.equals(curve1))
@@ -172,12 +172,12 @@ describe('Ecurve', function() {
       var p1 = BigInteger.fromHex("FFFFFFFDFFFFFFFFFFFFFFFFFFFFFFFF")
       var a1 = BigInteger.fromHex("FFFFFFFDFFFFFFFFFFFFFFFFFFFFFFFC")
       var b1 = BigInteger.fromHex("E87579C11079F43DD824993C2CEE5ED3")
-      var curve1 = new ECCurveFp(p1, a1, b1)
+      var curve1 = new Curve(p1, a1, b1)
 
       var p2 = BigInteger.fromHex("FFFFFFFDFFFFFFFFFFFFFFFFFFFFFFAA")
       var a2 = a1.clone()
       var b2 = b1.clone()
-      var curve2 = new ECCurveFp(p2, a2, b2)
+      var curve2 = new Curve(p2, a2, b2)
 
       assert(!curve1.equals(curve2))
       assert(!curve2.equals(curve1))

--- a/test/point.test.js
+++ b/test/point.test.js
@@ -3,16 +3,16 @@ var assert= require('assert')
 var BigInteger = require('bigi')
 
 var ecurve = require('../')
-var ECCurveFp = ecurve.ECCurveFp
-var ECPointFp = ecurve.ECPointFp
+var Curve = ecurve.Curve
+var Point = ecurve.Point
 var getECParams = ecurve.getECParams
 
 var fixtures = require('./fixtures/point')
 
-describe('ECPointFp', function() {
+describe('Point', function() {
   describe('+ decodeFrom()', function() {
     it('should be an static (class) method', function() {
-      assert.equal(typeof ECPointFp.decodeFrom, 'function')
+      assert.equal(typeof Point.decodeFrom, 'function')
     })
 
     var pubHex = '04d6d48c4a66a303856d9584a6ad49ce0965e9f0a5e4dcae878a3d017bd58ad7af3d0b920af7bd54626103848150f8b083edcba99d0a18f1035b6036da1500c6c0'
@@ -21,15 +21,15 @@ describe('ECPointFp', function() {
 
     it('should work with uncompressed keys', function(){
       var curve = getECParams('secp256k1').curve
-      var pubPoint = ECPointFp.decodeFrom(curve, pubKey)
+      var pubPoint = Point.decodeFrom(curve, pubKey)
       assert.equal(pubHex, pubPoint.getEncoded(false).toString('hex'))
     })
 
     it('should work with compressed keys', function() {
       var curve = getECParams('secp256k1').curve
-      var pubPoint = ECPointFp.decodeFrom(curve, pubKey)
+      var pubPoint = Point.decodeFrom(curve, pubKey)
       var pubKeyCompressed = pubPoint.getEncoded(true)
-      var pubPointCompressed = ECPointFp.decodeFrom(curve, pubKeyCompressed)
+      var pubPointCompressed = Point.decodeFrom(curve, pubKeyCompressed)
       assert.equal(pubHex, pubPointCompressed.getEncoded(false).toString('hex'))
       assert.equal(pubKeyCompressed.toString('hex'), pubPointCompressed.getEncoded(true).toString('hex'))
       assert.equal(pubHexCompressed, pubKeyCompressed.toString('hex'))
@@ -40,7 +40,7 @@ describe('ECPointFp', function() {
         var curve = getECParams(f.curve).curve
         var buffer = new Buffer(f.hex, 'hex')
 
-        var decoded = ECPointFp.decodeFrom(curve, buffer)
+        var decoded = Point.decodeFrom(curve, buffer)
         assert.equal(decoded.getX().toString(), f.x)
         assert.equal(decoded.getY().toString(), f.y)
         assert.equal(decoded.compressed, f.compressed)
@@ -53,7 +53,7 @@ describe('ECPointFp', function() {
         var buffer = new Buffer(f.hex, 'hex')
 
         assert.throws(function() {
-          ECPointFp.decodeFrom(curve, buffer)
+          Point.decodeFrom(curve, buffer)
         }, /Invalid sequence length|Invalid sequence tag/)
       })
     })
@@ -63,7 +63,7 @@ describe('ECPointFp', function() {
     fixtures.valid.forEach(function(f) {
       it('encode ' + f.hex + ' correctly', function() {
         var curve = getECParams(f.curve).curve
-        var Q = new ECPointFp(curve, new BigInteger(f.x), new BigInteger(f.y))
+        var Q = new Point(curve, new BigInteger(f.x), new BigInteger(f.y))
 
         var encoded = Q.getEncoded(f.compressed)
         assert.equal(encoded.toString('hex'), f.hex)
@@ -79,7 +79,7 @@ describe('ECPointFp', function() {
           var curve = getECParams('secp256k1').curve
           var doCompress = false
 
-          var Q = new ECPointFp(curve, new BigInteger(x), new BigInteger(y))
+          var Q = new Point(curve, new BigInteger(x), new BigInteger(y))
           Q.compressed = true
 
           var encoded = Q.getEncoded(doCompress)
@@ -95,7 +95,7 @@ describe('ECPointFp', function() {
           var curve = getECParams('secp256k1').curve
           var doCompress = true
 
-          var Q = new ECPointFp(curve, new BigInteger(x), new BigInteger(y))
+          var Q = new Point(curve, new BigInteger(x), new BigInteger(y))
           Q.compressed = true
 
           var encoded = Q.getEncoded(doCompress)
@@ -113,7 +113,7 @@ describe('ECPointFp', function() {
           var curve = getECParams('secp256k1').curve
           var doCompress = false
 
-          var Q = new ECPointFp(curve, new BigInteger(x), new BigInteger(y))
+          var Q = new Point(curve, new BigInteger(x), new BigInteger(y))
           Q.compressed = false
 
           var encoded = Q.getEncoded(doCompress)
@@ -129,7 +129,7 @@ describe('ECPointFp', function() {
           var curve = getECParams('secp256k1').curve
           var doCompress = true
 
-          var Q = new ECPointFp(curve, new BigInteger(x), new BigInteger(y))
+          var Q = new Point(curve, new BigInteger(x), new BigInteger(y))
           Q.compressed = false
 
           var encoded = Q.getEncoded(doCompress)
@@ -146,7 +146,7 @@ describe('ECPointFp', function() {
           var res = "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
           var curve = getECParams('secp256k1').curve
 
-          var Q = new ECPointFp(curve, new BigInteger(x), new BigInteger(y))
+          var Q = new Point(curve, new BigInteger(x), new BigInteger(y))
           Q.compressed = false
 
           var encoded = Q.getEncoded()
@@ -161,7 +161,7 @@ describe('ECPointFp', function() {
           var res = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
           var curve = getECParams('secp256k1').curve
 
-          var Q = new ECPointFp(curve, new BigInteger(x), new BigInteger(y))
+          var Q = new Point(curve, new BigInteger(x), new BigInteger(y))
           Q.compressed = true
 
           var encoded = Q.getEncoded()
@@ -177,11 +177,11 @@ describe('ECPointFp', function() {
     it('should return true when points are equal', function() {
       var x1 = BigInteger.fromHex("FFFF")
       var y1 = BigInteger.fromHex("FFFF")
-      var P1 = new ECPointFp(curve, x1, y1)
+      var P1 = new Point(curve, x1, y1)
 
       var x2 = x1.clone()
       var y2 = y1.clone()
-      var P2 = new ECPointFp(curve, x2, y2)
+      var P2 = new Point(curve, x2, y2)
 
       assert(P1.equals(P2))
       assert(P2.equals(P1))
@@ -190,11 +190,11 @@ describe('ECPointFp', function() {
     it('should return false when points are noassertequal', function() {
       var x1 = BigInteger.fromHex("FFFF")
       var y1 = BigInteger.fromHex("FFFF")
-      var P1 = new ECPointFp(curve, x1, y1)
+      var P1 = new Point(curve, x1, y1)
 
       var x2 = BigInteger.fromHex("AAAA")
       var y2 = y1.clone()
-      var P2 = new ECPointFp(curve, x2, y2)
+      var P2 = new Point(curve, x2, y2)
 
       assert(!P1.equals(P2))
       assert(!P2.equals(P1))
@@ -211,18 +211,18 @@ describe('ECPointFp', function() {
     })
 
     it('should return true for points at (0, 0) if they are on the curve', function() {
-      var curve = new ECCurveFp(BigInteger.valueOf(11), BigInteger.ONE, BigInteger.ZERO)
-      var P = new ECPointFp(curve, BigInteger.ZERO, BigInteger.ZERO)
+      var curve = new Curve(BigInteger.valueOf(11), BigInteger.ONE, BigInteger.ZERO)
+      var P = new Point(curve, BigInteger.ZERO, BigInteger.ZERO)
       assert.ok(P.isOnCurve())
     })
 
     it('should return false for points not in the finite field', function() {
-      var P = new ECPointFp(curve, curve.p.add(BigInteger.ONE), BigInteger.ZERO)
+      var P = new Point(curve, curve.p.add(BigInteger.ONE), BigInteger.ZERO)
       assert(!P.isOnCurve())
     })
 
     it('should return false for a point not on the curve', function() {
-      var P = new ECPointFp(curve, BigInteger.ONE, BigInteger.ONE)
+      var P = new Point(curve, BigInteger.ONE, BigInteger.ONE)
       assert(!P.isOnCurve())
     })
   })
@@ -238,7 +238,7 @@ describe('ECPointFp', function() {
     })
 
     it('should not validate a point not on the curve', function() {
-      var P = new ECPointFp(curve, BigInteger.ONE, BigInteger.ONE)
+      var P = new Point(curve, BigInteger.ONE, BigInteger.ONE)
 
       assert.throws(function() {
         P.validate()


### PR DESCRIPTION
This removes the unnecessary `EC*Fp` prefix/suffixes on the two classes in the project.
A typical use case:

```
var ecurve = require('ecurve')

ecurve.Point.decodeFrom(myCurve, someBytes)
```

If they omit the `ecurve` for convenience, then, it is understood that they are throwing away the namespacing information.  No need to double up.
