### PR TITLE
curve: remove params object

### DIFF
--- a/lib/curve.js
+++ b/lib/curve.js
@@ -9,13 +9,11 @@ function Curve(p, a, b, Gx, Gy, n, h) {
   this.p = p
   this.a = a
   this.b = b
-  this.infinity = new Point(this, null, null, BigInteger.ZERO)
+  this.G = Point.fromAffine(this, Gx, Gy),
+  this.n = n
+  this.h = h
 
-  this.params = {
-    G: Point.fromAffine(this, Gx, Gy),
-    h: h,
-    n: n
-  }
+  this.infinity = new Point(this, null, null, BigInteger.ZERO)
 }
 
 Curve.prototype.isInfinity = function(Q) {
@@ -54,7 +52,7 @@ Curve.prototype.validate = function(Q) {
   assert(this.isOnCurve(Q), 'Point is not on the curve')
 
   // Check nQ = O (where Q is a scalar multiple of G)
-  var nQ = Q.multiply(this.params.n)
+  var nQ = Q.multiply(this.n)
   assert(this.isInfinity(nQ), 'Point is not a scalar multiple of G')
 
   return true

--- a/test/curve.test.js
+++ b/test/curve.test.js
@@ -23,9 +23,9 @@ describe('Ecurve', function() {
     assert(curve.a.equals(a))
     assert(curve.b.equals(b))
 
-    assert(curve.params.G.equals(Point.fromAffine(curve, Gx, Gy)))
-    assert(curve.params.n.equals(n))
-    assert(curve.params.h.equals(h))
+    assert(curve.G.equals(Point.fromAffine(curve, Gx, Gy)))
+    assert(curve.n.equals(n))
+    assert(curve.h.equals(h))
     assert(curve.a.equals(a))
     assert(curve.b.equals(b))
   });
@@ -35,7 +35,7 @@ describe('Ecurve', function() {
       var curve = ecurve.getCurveByName(f.Q.curve)
 
       var d = new BigInteger(f.D)
-      var Q = curve.params.G.multiply(d)
+      var Q = curve.G.multiply(d)
 
       assert.ok(Q.affineX.toString(), f.Q.x)
       assert.ok(Q.affineY.toString(), f.Q.y)
@@ -80,14 +80,11 @@ describe('Ecurve', function() {
     })
 
     // pG = P = -P
-    var P = curve.params.G.multiply(curve.p)
-    assert(P.equals(curve.params.G.negate()))
+    var P = curve.G.multiply(curve.p)
+    assert(P.equals(curve.G.negate()))
 
     // nG = O
-    console.log(curve)
-    console.log(curve.params)
-    console.log(curve.params.n)
-    var nG = curve.params.G.multiply(curve.params.n)
+    var nG = curve.G.multiply(curve.n)
     assert(curve.isInfinity(nG))
 
     var inf = curve.infinity
@@ -165,7 +162,7 @@ describe('Ecurve', function() {
 
     it('should return true for a point on the curve', function() {
       var d = BigInteger.ONE
-      var Q = curve.params.G.multiply(d)
+      var Q = curve.G.multiply(d)
       assert.ok(curve.isOnCurve(Q))
     })
 
@@ -191,7 +188,7 @@ describe('Ecurve', function() {
 
     it('should validate a point on the curve', function() {
       var d = BigInteger.ONE
-      var Q = curve.params.G.multiply(d)
+      var Q = curve.G.multiply(d)
 
       assert.ok(curve.validate(Q))
     })

--- a/test/names.test.js
+++ b/test/names.test.js
@@ -13,9 +13,9 @@ describe('+ getCurveByName(curveName)', function() {
       assert.equal(curve.p.toBuffer().toString('hex'), 'fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f')
       assert.equal(curve.a.toBuffer().toString('hex'), '') // 0 becomes ''
       assert.equal(curve.b.toBuffer().toString('hex'), '07')
-      assert.equal(curve.params.G.getEncoded(false).toString('hex'), '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8')
-      assert.equal(curve.params.n.toBuffer().toString('hex'), 'fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141')
-      assert.equal(curve.params.h.toBuffer().toString('hex'), '01')
+      assert.equal(curve.G.getEncoded(false).toString('hex'), '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8')
+      assert.equal(curve.n.toBuffer().toString('hex'), 'fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141')
+      assert.equal(curve.h.toBuffer().toString('hex'), '01')
     })
   })
 


### PR DESCRIPTION
As discussed, this pull request removes the anonymous (and mostly irrelevant) `params` object from the `Curve` object.
Our `Curve` object is already non-generic, and the `params` object was a non-useful abstraction.
Therefore, it has been removed in favour of the `SEC` approach of a simple sextuple for representing curves.
